### PR TITLE
Fix purchase and sale date validation

### DIFF
--- a/app/models/sale.rb
+++ b/app/models/sale.rb
@@ -12,9 +12,9 @@ class Sale < ActiveRecord::Base
                             allow_blank: true
 
   validates :sale_date, date: { allow_nil: true }
-  validates :purchase_date, date: {
-            after_or_equal_to: :sale_date,
-            message: :greater_than_or_equal_to_sale_date,
+  validates :sale_date, date: {
+            after_or_equal_to: :purchase_date,
+            message: :greater_than_or_equal_to_purchase_date,
             allow_nil: true }
   validates :incoming_invoice_date, date: { allow_nil: true }
   validates :output_invoice_date, date: {

--- a/app/views/sales/_form.html.erb
+++ b/app/views/sales/_form.html.erb
@@ -20,8 +20,7 @@
                 </div>
               </div><!-- /.form-inputs -->
             </div><!-- /.row -->
-
-            <div class='row'>
+<div class='row'>
               <div class='form-inputs'>
                 <div class='col-md-3'><%= fv.input :brand, vue: {"v-model": 'vehicle.brand', ':disabled': 'isVehicleLoaded', ref: 'brand'} %></div>
                 <div class='col-md-3'><%= fv.input :version, vue: {"v-model": 'vehicle.version', ':disabled': 'isVehicleLoaded'} %></div>
@@ -214,10 +213,8 @@
 
           <div class='row'>
             <div class='form-inputs'>
-              <div class='col-md-2'>
-                <%= f.input :sale_price, as: :string, vue: {'ref': 'salePrice'}, input_html: { class: 'money' } %>
-              </div><!-- /.col-md-2 -->
-              <div class='col-md-2'><%= f.input :sale_date, as: :string, input_html: { class: 'date' } %></div>
+              <div class='col-md-2'><%= f.input :purchase_price, as: :string, input_html: { class: 'money' } %></div>
+              <div class='col-md-2'><%= f.input :purchase_date, as: :string, input_html: { class: 'date' } %></div>
               <div class='col-md-2'><%= f.input :incoming_invoice_number %></div>
               <div class='col-md-2'><%= f.input :incoming_invoice_date, as: :string, input_html: { class: 'date' } %></div>
             </div><!-- /.form-inputs' -->
@@ -225,8 +222,10 @@
 
           <div class='row'>
             <div class='form-inputs'>
-              <div class='col-md-2'><%= f.input :purchase_price, as: :string, input_html: { class: 'money' } %></div>
-              <div class='col-md-2'><%= f.input :purchase_date, as: :string, input_html: { class: 'date' } %></div>
+              <div class='col-md-2'>
+                <%= f.input :sale_price, as: :string, vue: {'ref': 'salePrice'}, input_html: { class: 'money' } %>
+              </div><!-- /.col-md-2 -->
+              <div class='col-md-2'><%= f.input :sale_date, as: :string, input_html: { class: 'date' } %></div>
               <div class='col-md-2'><%= f.input :output_invoice_number %></div>
               <div class='col-md-2'><%= f.input :output_invoice_date, as: :string, input_html: { class: 'date' } %></div>
             </div><!-- /.form-inputs' -->

--- a/config/locales/pt-BR/models/sale.yml
+++ b/config/locales/pt-BR/models/sale.yml
@@ -21,8 +21,8 @@ pt-BR:
       models:
         sale:
           attributes:
-            purchase_date:
-              greater_than_or_equal_to_sale_date: deve ser maior ou igual a data de venda
+            sale_date:
+              greater_than_or_equal_to_purchase_date: deve ser maior ou igual a data da compra
             output_invoice_date:
               greater_than_or_equal_to_incoming_invoice_date: deve ser maior ou igual a data de entrada NFE
             output_invoice_number:

--- a/spec/factories/sale.rb
+++ b/spec/factories/sale.rb
@@ -2,13 +2,13 @@ FactoryGirl.define do
   factory :sale do
     association :vehicle, strategy: :build
     association :seller, factory: :customer, strategy: :build
-    sale_price 20000.0
-    sale_date '10/01/2016'
+    purchase_price 20000.0
+    purchase_date '10/01/2016'
     incoming_invoice_number '123456'
     incoming_invoice_date '10/01/2016'
     association :purchaser, factory: :customer, strategy: :build
-    purchase_price 22000.0
-    purchase_date '11/01/2016'
+    sale_price 22000.0
+    sale_date '11/01/2016'
     output_invoice_number '654321'
     output_invoice_date '11/01/2016'
     brokerage false

--- a/spec/features/sale/create_a_sale_spec.rb
+++ b/spec/features/sale/create_a_sale_spec.rb
@@ -74,15 +74,15 @@ feature 'Create a sale' do
     end
 
     within "fieldset[name='sale-informations']" do
-      fill_in 'Preço de venda', with: 20000.0
-      fill_in 'Data da venda', with: '10/01/2016'
+      fill_in 'Preço de compra', with: 20000.0
+      fill_in 'Data da compra', with: '10/01/2016'
       fill_in 'NFE de entrada', with: '123456'
-      fill_in 'Data de entrada NFE', with: '21/01/2016'
+      fill_in 'Data de entrada NFE', with: '11/01/2016'
 
-      fill_in 'Preço de compra', with: 22000.0
-      fill_in 'Data da compra', with: '20/01/2016'
+      fill_in 'Preço de venda', with: 22000.0
+      fill_in 'Data da venda', with: '20/01/2016'
       fill_in 'NFE de saída', with: '123457'
-      fill_in 'Data de saída NFE', with: '22/01/2016'
+      fill_in 'Data de saída NFE', with: '21/01/2016'
 
       fill_in 'Observação', with: 'Observation about sale'
       check 'Corretagem'
@@ -98,9 +98,9 @@ feature 'Create a sale' do
     expect(page).to have_content 'Purchaser'
     expect(page).to have_content '123456'
     expect(page).to have_content '10/01/2016'
+    expect(page).to have_content '11/01/2016'
     expect(page).to have_content '20/01/2016'
     expect(page).to have_content '21/01/2016'
-    expect(page).to have_content '22/01/2016'
     expect(page).to have_content 'Observation about sale'
   end
 end

--- a/spec/features/sale/show_a_vehicle_spec.rb
+++ b/spec/features/sale/show_a_vehicle_spec.rb
@@ -6,12 +6,12 @@ feature 'Show a vehicle' do
       seller: create(:customer, full_name: 'Seller'),
       purchaser: create(:customer, full_name: 'Purchaser'),
       vehicle: create(:vehicle,  brand: 'Audi', version: 'A4 2.0 AT', maker_year: 2014, model_year: 2015),
-      sale_price: 20000.0,
-      sale_date: '10/10/2015',
+      purchase_price: 20000.0,
+      purchase_date: '10/10/2015',
       incoming_invoice_number: '123456',
       incoming_invoice_date: '11/10/2015',
-      purchase_price: 22000.0,
-      purchase_date: '20/10/2015',
+      sale_price: 22000.0,
+      sale_date: '20/10/2015',
       output_invoice_number: '654321',
       output_invoice_date: '21/10/2015',
       brokerage: false,
@@ -31,7 +31,7 @@ feature 'Show a vehicle' do
     expect(page).to have_content 'A4 2.0 AT'
     expect(page).to have_content '2014'
     expect(page).to have_content '2015'
-    expect(page).to have_content '20/10/2015'
+    expect(page).to have_content '10/10/2015'
   end
 
   scenario 'with success' do

--- a/spec/models/sale_spec.rb
+++ b/spec/models/sale_spec.rb
@@ -21,19 +21,18 @@ describe Sale, type: :model do
     context 'sale date' do
       it { is_expected.to validate_presence_of(:sale_date) }
       it { is_expected.to date_cannot_be_in_the_future(:sale_date) }
+
+      it 'cannot be less than purchase date' do
+        subject.purchase_date = Date.new(2016, 10, 10)
+        subject.sale_date = Date.new(2016, 10, 9)
+
+        is_expected.to be_invalid
+        expect(subject.errors[:sale_date]).to include('deve ser maior ou igual a data da compra')
+      end
     end
 
     context 'purchase date' do
       it { is_expected.to validate_presence_of(:purchase_date) }
-
-      it 'cannot be less than sale date' do
-        subject.sale_date = Date.new(2016, 10, 10)
-        subject.purchase_date = Date.new(2016, 10, 9)
-
-        is_expected.to be_invalid
-        expect(subject.errors[:purchase_date]).to include('deve ser maior ou igual a data de venda')
-      end
-
       it { is_expected.to date_cannot_be_in_the_future(:purchase_date) }
     end
 


### PR DESCRIPTION
### Sale date should be greater or equal than purchase date

- Invert validation logic between purchase date and sale date
- Invert the fields dispositions to make sense for user

#### Before
<img width="1157" alt="screen shot 2017-09-24 at 12 40 20" src="https://user-images.githubusercontent.com/2837358/30784135-9ef8bf3a-a125-11e7-833b-666a71febd4f.png">


----

#### After
<img width="1049" alt="screen shot 2017-09-24 at 12 36 56" src="https://user-images.githubusercontent.com/2837358/30784124-3a0e0184-a125-11e7-9cb8-19809846238d.png">
 